### PR TITLE
Added - queue level job management

### DIFF
--- a/controllers/jobs.js
+++ b/controllers/jobs.js
@@ -21,7 +21,8 @@ module.exports = function (app) {
 
     app.get('/api/jobs/delete/status/:type', function (req, res) {
         var type = req.param("type");
-        redisModel.deleteJobByStatus(type).done(function(results){
+        var queueName = req.param("queueName") ? req.param("queueName") : null;
+        redisModel.deleteJobByStatus(type, queueName).done(function(results){
             res.json(results);
         });
     });

--- a/public/js/RedisHandler.js
+++ b/public/js/RedisHandler.js
@@ -31,7 +31,8 @@ var RedisHandler = function(){
                 });
             });
         },
-        deleteByStatus: function(status){
+        deleteByStatus: function(status, obj){
+            var queueName = obj.name;
             status = status.toLowerCase();
             var statusDisplay = status;
             if(status === "pending"){
@@ -40,7 +41,13 @@ var RedisHandler = function(){
             }
             _self.util.notyConfirm("Are you sure you want to delete <strong>all</strong> jobs with the status "+statusDisplay+"?", function(){
                 _self.util.blockUI();
-                $.getJSON(window.basepath + "/api/jobs/delete/status/"+status).done(function(response){
+                var targetUrl = null;
+                if (queueName) {
+                  targetUrl = window.basepath + "/api/jobs/delete/status/"+status + "?queueName=" + queueName;
+                } else {
+                  targetUrl = window.basepath + "/api/jobs/delete/status/"+status;
+                }
+                $.getJSON(targetUrl).done(function(response){
                     if(status !== statusDisplay && response.success){
                         response.message = response.message.replace(status, statusDisplay);
                     }

--- a/public/templates/queueList.dust
+++ b/public/templates/queueList.dust
@@ -19,6 +19,7 @@ Matador
             <th>Active</th>
             <th>Completed</th>
             <th>Failed</th>
+            <th>Options</th>
         </tr>
         </thead>
         <tbody data-bind="foreach: keys">
@@ -30,6 +31,20 @@ Matador
             <td data-bind="text: active"></td>
             <td data-bind="text: completed"></td>
             <td data-bind="text: failed"></td>
+            <td>
+              <div class="dropdown">
+                <button data-toggle="dropdown" data-bind="attr: { id: 'queue_dropdown_' + $index() }" class="btn btn-default dropdown-toggle">
+                  <i class="fa fa-cog"></i> 
+                  <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu dropdown-menu-right" data-bind="attr: { "aria-labelledby": 'queue_dropdown_' + $index() }">
+                    <li><a href="#" data-bind="click: function(data, event) { redisHandler.fn.deleteByStatus('wait', data) }">Delete All Pending</a></li>
+                    <li><a href="#" data-bind="click: function(data, event) { redisHandler.fn.deleteByStatus('active', data) }">Delete All Active</a></li>
+                    <li><a href="#" data-bind="click: function(data, event) { redisHandler.fn.deleteByStatus('complete', data) }">Delete All Completed</a></li>
+                    <li><a href="#" data-bind="click: function(data, event) { redisHandler.fn.deleteByStatus('failed', data) }">Delete All Failed</a></li>
+                </ul>
+              </div>
+            </td>
         </tr>
         </tbody>
     </table>


### PR DESCRIPTION
Hi,

I noticed some issues when the number of items in the bull queue surpass 50K or more. It becomes very difficult to clear jobs like completed/failed etc. Sometimes the tab also crashes as the Javascript tries to load those 50K jobs all at the same time.

I added this hotfix to allow people to clear jobs right from the /queues controller.

![screenshot from 2016-01-05 00 44 08](https://cloud.githubusercontent.com/assets/5372612/12098081/dfde20f0-b345-11e5-8fad-3d05d64be4f6.png)

Let me know about any changes.

Thanks!