### PR TITLE
fix Matador queue display bug

### DIFF
--- a/models/redis.js
+++ b/models/redis.js
@@ -77,7 +77,10 @@ var getStatus = function(status){
         var multi = [];
         var statusKeys = [];
         for(var i = 0, ii = keys.length; i < ii; i++){
-            statusKeys[keys[i].split(":")[1]] = []; // This creates an array/object thing with keys of the job type
+             var arr = keys[i].split(":");
+            var queueName = arr.slice(1, arr.length - 1);
+            var queue = queueName.join(":");
+            statusKeys[queue] = []; // This creates an array/object thing with keys of the job type
             if(status === "active" || status === "wait"){
                 multi.push(['lrange', keys[i], 0, -1]);
             }else{
@@ -137,7 +140,6 @@ var getJobsInList = function(list){
     if(!list) return;
     var dfd = q.defer();
     var jobs = [];
-
     if(list["keys"]){
         //New list type
         var keys = list["keys"];
@@ -175,7 +177,7 @@ var getStatusCounts = function(){
                             stuck: allKeys.length - (active.count+completed.count+failed.count+pendingKeys.count),
                             queues: keys.length
                         };
-                        dfd.resolve(countObject);
+                       dfd.resolve(countObject);
                       });
                     });
                 });
@@ -187,7 +189,6 @@ var getStatusCounts = function(){
 
 var formatKeys = function(keys){
     if(!keys) return;
-
     var dfd = q.defer();
     getStatus("failed").done(function(failedJobs){
         getStatus("complete").done(function(completedJobs){
@@ -195,7 +196,13 @@ var formatKeys = function(keys){
                 getStatus("wait").done(function(pendingJobs){
                     var keyList = [];
                     for(var i = 0, ii = keys.length; i < ii; i++){
-                        var explodedKeys = keys[i].split(":");
+                        var arr = keys[i].split(":");
+                        var queueName = arr.slice(1, arr.length - 1);
+                        var queue = queueName.join(":");
+                        var explodedKeys = {};
+                        explodedKeys[0] = arr[0];
+                        explodedKeys[1] = queue;
+                        explodedKeys[2] = arr[arr.length-1];
                         var status = "stuck";
                         if(activeJobs.keys[explodedKeys[1]] && activeJobs.keys[explodedKeys[1]].indexOf(explodedKeys[2]) !== -1) status = "active";
                         else if(completedJobs.keys[explodedKeys[1]] && completedJobs.keys[explodedKeys[1]].indexOf(explodedKeys[2]) !== -1) status = "complete";
@@ -203,6 +210,7 @@ var formatKeys = function(keys){
                         else if(pendingJobs.keys[explodedKeys[1]] && pendingJobs.keys[explodedKeys[1]].indexOf(explodedKeys[2]) !== -1) status = "pending";
                         keyList.push({id: explodedKeys[2], type: explodedKeys[1], status: status});
                     }
+                   
                     keyList = _.sortBy(keyList, function(key){return parseInt(key.id);});
                     dfd.resolve(keyList);
                 });
@@ -232,7 +240,6 @@ var makePendingByType = function(type){
     type = type.toLowerCase();
     var validTypes = ['active', 'complete', 'failed', 'wait']; //I could add stuck, but I won't support mass modifying "stuck" jobs because it's very possible for things to be in a "stuck" state temporarily, while transitioning between states
     var dfd = q.defer();
-    console.log(validTypes.indexOf(type));
     if(validTypes.indexOf(type) === -1) {
         dfd.resolve({success:false, message:"Invalid type: "+type+" not in list of supported types"});
         return dfd.promise;


### PR DESCRIPTION
We have queues with `:` in the queue name, which Matador fails to show correctly and also fails to let you do delete, re-activate, etc operations on. Credit to @d2marcelo for the fixes.