### PR TITLE
[IMPROVEMENT] bumped bull, redis to latest, fixes a specified db from the config

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,14 +6,14 @@
   "dependencies": {
     "bluebird": "^2.9.24",
     "body-parser": "^1.13.3",
-    "bull": "~0.2.4",
+    "bull": "^0.7.2",
     "consolidate": "~0.10.0",
     "dustjs-linkedin": "~2.5.1",
     "express": "~4.10.8",
     "less": "~2.1.2",
     "lodash": "~2.4.1",
     "q": "~1.1.2",
-    "redis": "~0.12.1"
+    "redis": "^2.5.3"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
@ShaneK  Bull was updated 4/8/16 to fix a longstanding issue which now allows the user to correctly select the db number for each queue in redis CreateClient; so as far as Matador is concerned updating both the bull and redis package are required to allow the user to select the db from within the config and will easily make Matador feature compatible with the new Bull.

e.g..

    {
    "port": 1337,
    "redis": {
        "host": "localhost",
        "port": 6379,
        "options" : {
          "db" : 2
        }
    },
    "errorPages": {
        "404": "errors/404",
        "not-connected": "errors/not-connected"
    },
    "development": true
    }
