### PR TITLE
Support Redis URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ var matador = require('bull-ui/app')({
 });
 ```
 
+Or use a URL:
+
+```js
+var matador = require('bull-ui/app')({
+  redis: {
+    url: "redis://u:password@hostname",
+  }
+});
+```
+
 If you are including matador inside of another express app, declare the basepath when you mount it to the other app.
 
 ```js

--- a/lib/redisConnector.js
+++ b/lib/redisConnector.js
@@ -3,8 +3,6 @@ var redisAdapter = require('redis'),
     updateInfo = require('./updateInfo');
 
 exports.connect = function(settings){
-    var redis;
-
     Promise.promisifyAll(redisAdapter);
     if(settings.url) {
         redis = redisAdapter.createClient(settings.url, settings.options);

--- a/lib/redisConnector.js
+++ b/lib/redisConnector.js
@@ -3,10 +3,16 @@ var redisAdapter = require('redis'),
     updateInfo = require('./updateInfo');
 
 exports.connect = function(settings){
+    var redis;
+
     Promise.promisifyAll(redisAdapter);
-    redis = redisAdapter.createClient(settings.port, settings.host, settings.options);
-    if(settings.password){
-        redis.auth(settings.password);
+    if(settings.url) {
+        redis = redisAdapter.createClient(settings.url, settings.options);
+    } else {
+        redis = redisAdapter.createClient(settings.port, settings.host, settings.options);
+        if(settings.password){
+            redis.auth(settings.password);
+        }
     }
     redis.on("error", console.log);
     updateInfo.startUpdatingInfo();


### PR DESCRIPTION
The Redis adapter supports the use of URL, but the way that Matador passes the Redis connection information did not support this. I simply added the support for `url` but there may a more elegant way to pass all of the Redis settings through to the adapter.